### PR TITLE
(WIP) line chart from GAMA data (csv)

### DIFF
--- a/public/js/appData.js
+++ b/public/js/appData.js
@@ -6,3 +6,4 @@ let currentUserMode = 'questionnaire';
 
 let simulation_df
 let questions
+let GAMAData

--- a/public/js/d3Basic_line_chart.js
+++ b/public/js/d3Basic_line_chart.js
@@ -11,7 +11,7 @@ const margin = {
 
 let svg
 
-const createD3BasicLineChart = function (targetSelector, csvURL) {
+const createD3BasicLineChart = function (targetSelector) {
   // const margin = { top: 10, right: 30, bottom: 30, left: 60 },
   //   width = 460 - margin.left - margin.right,
   //   height = 400 - margin.top - margin.bottom;
@@ -25,15 +25,19 @@ const createD3BasicLineChart = function (targetSelector, csvURL) {
     .attr("transform", `translate(${margin.left},${margin.top})`);
   console.log("moin", svg)
   //Read the data
-  const sampleCsvURL = "https://raw.githubusercontent.com/holtzy/data_to_viz/master/Example_dataset/3_TwoNumOrdered_comma.csv"
-  d3.csv(sampleCsvURL,
-
+  const GAMADataApiURL = "http://localhost:8000/api/GAMAData"
+  let csvRowCount = 0
+  d3.csv(GAMADataApiURL,
+  // d3.csv(csvData, 
     // When reading the csv, I must format variables:
     function (d) {
-      return { date: d3.timeParse("%Y-%m-%d")(d.date), value: d.value }
+      if (csvRowCount > 9497) return
+      csvRowCount += 1
+      const formatDate= d.current_date.match(/'([^']+)'/)[1].slice(0,11)
+      return { date: d3.timeParse("%Y-%m-%d ")(formatDate), value: d.value }
     }).then(data => {
       drawBasicLineChartFromData(data)
-    })
+    }).catch(err => { console.log("error while processing CSV with D3", err) })
 }
 
 // Now I can use this dataset:
@@ -58,7 +62,7 @@ const drawBasicLineChartFromData = function (data) {
   svg.append("path")
     .datum(data)
     .attr("fill", "none")
-    .attr("stroke", "steelblue")
+    .attr("stroke", "red")
     .attr("stroke-width", 1.5)
     .attr("d", d3.line()
       .x(function (d) { return x(d.date) })

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -58,9 +58,16 @@ async function fetchQuestions() {
   return retval
 }
 
+async function fetchGAMAData() {
+  const questionsObject = await fetchDataFromApi('GAMAData');
+  const retval = questionsObject.data
+  return retval
+}
+
 
 simulation_df = await fetchSimulationDataFrame()
 questions = await fetchQuestions()
+GAMAData = await fetchGAMAData()
 
 
 

--- a/public/style.css
+++ b/public/style.css
@@ -50,7 +50,7 @@ body {
   background: black;
 }
 
-#infoscreen, .inputHouseholdsMode, .simulationMode {
+#infoscreen, .input_households, .simulationMode {
   width: 100%;
   height: 100%;
   font-size: 18px;

--- a/public/style.css
+++ b/public/style.css
@@ -312,20 +312,20 @@ g#xAxisG text, g#yAxisG text {
   grid-gap: 10px;
   grid-template-columns: 3fr 2fr ;
   /* grid-template-rows: repeat(2, [row] auto  ); */
-  background-color: #fff;
-  color: #444;
+  /* background-color: #fff; */
+  /* color: #444; */
 }
 
 .box {
-  background-color: #444;
-  color: #fff;
+  /* background-color: #444; */
+  /* color: #fff; */
   border-radius: 5px;
   padding: 20px;
 }
 
 .box .box {
-  background-color: #ccc;
-  color: #444;
+  /* background-color: #ccc; */
+  /* color: #444; */
 }
 
 .houseHolds {
@@ -333,9 +333,8 @@ g#xAxisG text, g#yAxisG text {
   grid-gap: 10px;
   grid-template-columns: repeat(3, 1fr);
   /* grid-template-rows: repeat(2, [row] auto  ); */
-  background-color: purple;
-  color: #444;
-
+  /* background-color: purple; */
+  /* color: #444; */
 }
 
 .houseHold {
@@ -367,6 +366,7 @@ g#xAxisG text, g#yAxisG text {
 
 .houseHoldEnergyEfficiency img {
   width: 25px;
+  filter:invert(1)
 }
 
 .houseHoldIsHeizung {

--- a/q100_info.js
+++ b/q100_info.js
@@ -42,10 +42,16 @@ function initServer() {
 
   // set endpoint for question.csv
   // see https://csv.js.org/parse/
-  const questionsFromCSV = loadAndParseCSV("public/data/questions.csv");
-  const questions = formatQuestions(questionsFromCSV)
+  const questions = loadQuestionsCSV()
   app.get('/api/questions', (req, res) => {
     res.json(questions);
+  });
+  
+  // set endpoint for .csv
+  // see https://csv.js.org/parse/
+  const GAMAData = loadGAMADataCSV()
+  app.get('/api/GAMAData', (req, res) => {
+    res.json(GAMAData);
   });
 
   open('http://localhost:' + http_port);
@@ -57,13 +63,14 @@ function loadAndParseJson(path) {
   return jsonData
 }
 
-function loadAndParseCSV(path) {
-  const input = fs.readFileSync(path, 'utf8');
-  const records = csv.parse(input, {
+function loadQuestionsCSV() {
+  const input = fs.readFileSync("public/data/questions.csv", 'utf8');
+  const questionsFromCSV = csv.parse(input, {
     delimiter: '/n',
     skip_empty_lines: true,
   });
-  return records 
+  const questions = formatQuestions(questionsFromCSV)
+  return questions
 }
 
 function formatQuestions(rawQuestions) {
@@ -72,4 +79,15 @@ function formatQuestions(rawQuestions) {
     questions.push(element[0])
   }
   return questions
+}
+
+function loadGAMADataCSV() {
+  const input = fs.readFileSync("public/data/includes/csv_export/csv_export_test.csv", 'utf8');
+  const GAMADataFromCSV = csv.parse(input, {
+    delimiter: ",",
+    skip_empty_lines: true,
+    columns: true,
+    to: 9499
+  });
+  return GAMADataFromCSV
 }

--- a/q100_info.js
+++ b/q100_info.js
@@ -49,9 +49,10 @@ function initServer() {
   
   // set endpoint for .csv
   // see https://csv.js.org/parse/
-  const GAMAData = loadGAMADataCSV()
   app.get('/api/GAMAData', (req, res) => {
-    res.json(GAMAData);
+  res.sendFile(path.join(__dirname,  
+      "public/data/includes/csv_export/csv_export_test.csv"
+    ))
   });
 
   open('http://localhost:' + http_port);
@@ -81,13 +82,3 @@ function formatQuestions(rawQuestions) {
   return questions
 }
 
-function loadGAMADataCSV() {
-  const input = fs.readFileSync("public/data/includes/csv_export/csv_export_test.csv", 'utf8');
-  const GAMADataFromCSV = csv.parse(input, {
-    delimiter: ",",
-    skip_empty_lines: true,
-    columns: true,
-    to: 9499
-  });
-  return GAMADataFromCSV
-}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29823397/173228119-076e9a47-8f33-4d62-8a06-303f3e7923aa.png)

Moin! Now data view uses the csv file from GAMA for the line chart. 

notions:
- Currently configured to use the first 9499 (in code 9497) rows of csv out of 39296 records.
- The original csv file had the third column named `(length(building where (each.mod_status = 's')) / length(building)) * 100`. I changed it to `value` since it was a bit hard to use. I uploaded it on SeaDrive at `Q-Scope_data/includes/csv_export/csv_export_test_columnNameEdit.csv`. For testing, please escape the original csv and use this file instead.
- I changed the colours that I was using for development purposes.
- fixed the bug that was mentioned #15  

If it looks fine, we can merge it into `workshop_prototype` branch. What do you think? @dunland  